### PR TITLE
fix NIP-98 authorization scheme

### DIFF
--- a/src/lib/authorization.ts
+++ b/src/lib/authorization.ts
@@ -81,7 +81,7 @@ const parseAuthEvent = async (req: Request, endpoint: string = "", checkAdminPri
 	try {
 		authevent = JSON.parse(
 			Buffer.from(
-				req.headers.authorization,
+				req.headers.authorization.split(' ')[1],
 				"base64"
 			).toString("utf8")
 		);


### PR DESCRIPTION
nostrcheck.me API returns 401 Unauthorized since 3-4 days ago.
```
POST https://nostrcheck.me/api/v1/media 401 (Unauthorized)
{"result":"error","description":"Malformed authorization header"}
```

[NIP-98](https://github.com/nostr-protocol/nips/blob/master/98.md) uses the Authorization scheme `Nostr` instead of `Bearer`.