### PR TITLE
fix: correct typo 'occured' -> 'occurred' in error message

### DIFF
--- a/src/init.ts
+++ b/src/init.ts
@@ -14,7 +14,7 @@ console.log("Starting Nostrcheck server", );
             console.info("Creating local config file: " + localPath, "Please edit the file and restart the server");
             exit(0);
         } catch (err) {
-            console.error("An error occured while writing config JSON File.", err);
+            console.error("An error occurred while writing config JSON File.", err);
             exit(1);
         }
     }


### PR DESCRIPTION
Corrects a simple typo in a console error message.

Fixed: `occured` → `occurred` in src/init.ts:17

This is a user-facing error message when the application fails to write the config JSON file.